### PR TITLE
fix(readme): Update removing macOS specific naming

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,9 @@
 #Slightly customized Solarized Dark for HyperTerm
 
-A port of the [Solarized Dark](http://ethanschoonover.com/solarized) theme for [Hyper.app](https://hyper.is/) made more legible.
+A port of the [Solarized Dark](http://ethanschoonover.com/solarized) theme for [Hyper](https://hyper.is/) made more legible.
 
 ### Installation
-1. Open Hyper.app's preferences by pressing `Cmd+,` or manually at `~/.hyper.js`.
+1. Open Hyper's preferences by pressing `Cmd + ,` or manually at `~/.hyper.js`.
 2. Find and Update the plugins array to include `hyper-almost-solarized-dark`:
 
   ```js
@@ -11,7 +11,7 @@ A port of the [Solarized Dark](http://ethanschoonover.com/solarized) theme for [
     'hyper-almost-solarized-dark'
   ],
   ```
-3. Reload Hyper.app by pressing `Cmd + Shft + R`
+3. Reload Hyper by pressing `Cmd + Shft + R`
 
 ### Credits
 - [@jxnblk](https://github.com/jxnblk)


### PR DESCRIPTION
Hyper is now available on a many platforms other than macOS, 
hence removed `.app`